### PR TITLE
Pin AWS CLI to version 2.13.33

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -11,7 +11,7 @@ function indent() {
   esac
 }
 
-AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"
+AWS_CLI_URL="https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.13.33.zip"
 
 BUILD_DIR=$1
 BUILDPACK_DIR="$(dirname $(dirname $0))"


### PR DESCRIPTION
Due to current bug in AWS CLI upstream dependencies that cause it to fail to install. https://github.com/aws/aws-cli/issues/8320